### PR TITLE
setup.py new version pip10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,16 @@
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
-from pip.req import parse_requirements
-from pip.download import PipSession
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
+try:  # for pip >= 10
+    from pip._internal.download import PipSession
+except ImportError:  # for pip <= 9.0.3
+    from pip.download import PipSession
 from drypy import get_version
+
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
with new version pip10 package dependencies used in make files are moved into ones with underscore. Example: pip.library -> pip._library