### PR TITLE
Added new decorator

### DIFF
--- a/drypy/docs/advanced.rst
+++ b/drypy/docs/advanced.rst
@@ -50,7 +50,7 @@ or *sheriff*, and provide a *deputy*:
 where :code:`self._deputy_of_write` should be defined with the same args of
 :code:`f.write` or with :code:`*args, **kw`.
 
-or *sentinel", and provide a return value:
+or *sentinel*, and provide a return value:
 
 .. code-block:: python
 

--- a/drypy/docs/advanced.rst
+++ b/drypy/docs/advanced.rst
@@ -50,6 +50,17 @@ or *sheriff*, and provide a *deputy*:
 where :code:`self._deputy_of_write` should be defined with the same args of
 :code:`f.write` or with :code:`*args, **kw`.
 
+or *sentinel", and provide a return value:
+
+.. code-block:: python
+
+           # write it to file
+           try:
+               with open('file.txt', 'a') as f:
+                   f.write = sentinel(return_value=None)(f.write)
+                   f.write(result)
+               ...
+
 .. important::
 
     If you apply the decorator inline as in the following example:

--- a/drypy/docs/quickstart.rst
+++ b/drypy/docs/quickstart.rst
@@ -73,3 +73,35 @@ When *drypy* dryrun mode is set to **True**, the function marked by
    Otherwise, if you think that the sheriff function signature may change in
    the future, you can use the generic syntax `*args, **kw` for the deputy
    args.
+
+
+Dryrun with mock
+----------------
+
+Sometimes we have a requirement to dryrun a function but also need to mock its 
+return value. The *sentinel* decorator can be used for this purpose:
+
+.. code-block:: python
+
+   from drypy.patterns import sentinel
+
+   @sentinel(return_value=42)
+   def foo(bar):
+       return 12
+
+Turning on *drypy* dryrun mode will now also mock the return value of *foo* 
+along with skipping execution and logging the call:
+
+   >>> from drypy import dryrun
+   >>> dryrun(True)
+   >>> result = foo(42)
+   [DRYRUN] call to 'foo(42)'
+   >>> result
+   42
+
+.. note::
+
+   *drypy* uses the python standard :py:mod:`logging` library therefore you
+   will need to setup valid handlers in order to get the messages.
+
+   *drypy* logs messages with the ``logging.INFO`` level.

--- a/drypy/patterns.py
+++ b/drypy/patterns.py
@@ -91,12 +91,12 @@ def sheriff(func):
     return decorator
 
 
-def saksag(return_value=None):
+def sentinel(return_value=None):
     """Decorator which makes drypy to log the call of the target
     function and returns a user defined value without executing it.
 
     Example 1:
-        >>> @saksag(return_value=25)
+        >>> @sentinel(return_value=25)
         ... def foo(bar, baz=None):
         ...     return 42
         ...
@@ -105,12 +105,12 @@ def saksag(return_value=None):
         42
         >>> dryrun(True)
         >>> b = foo("sport", baz=False)
-        INFO:drypy.saksag:[DRYRUN] call to 'foo(sport, baz=False)'
+        INFO:drypy.sentinel:[DRYRUN] call to 'foo(sport, baz=False)'
         >>> print(b)
         25
 
     Example 2:
-        >>> @saksag(return_value="I am Sakshi")
+        >>> @sentinel(return_value="I am Sakshi")
         ... def sakfoo(bar):
         ...     return "I am sakfoo"
         ...
@@ -119,7 +119,7 @@ def saksag(return_value=None):
         'I am sakfoo'
         >>> dryrun(True)
         >>> b = sakfoo("sport")
-        INFO:drypy.saksag:[DRYRUN] call to 'sakfoo(sport)'
+        INFO:drypy.sentinel:[DRYRUN] call to 'sakfoo(sport)'
         >>> print(b)
         'I am Sakshi'
 

--- a/drypy/patterns.py
+++ b/drypy/patterns.py
@@ -39,6 +39,7 @@ def sham(func):
             return None
     return decorator
 
+
 def sheriff(func):
     """Decorator which makes drypy to run *func.deputy*
     instead of *func*.
@@ -88,3 +89,53 @@ def sheriff(func):
     setattr(decorator, 'sheriff_name', func.__name__)
 
     return decorator
+
+
+def saksag(return_value=None):
+    """Decorator which makes drypy to log the call of the target
+    function and returns a user defined value without executing it.
+
+    Example 1:
+        >>> @saksag(return_value=25)
+        ... def foo(bar, baz=None):
+        ...     return 42
+        ...
+        >>> a = foo("sport", baz=False)
+        >>> print(a)
+        42
+        >>> dryrun(True)
+        >>> b = foo("sport", baz=False)
+        INFO:drypy.saksag:[DRYRUN] call to 'foo(sport, baz=False)'
+        >>> print(b)
+        25
+
+    Example 2:
+        >>> @saksag(return_value="I am Sakshi")
+        ... def sakfoo(bar):
+        ...     return "I am sakfoo"
+        ...
+        >>> a = sakfoo("sport")
+        >>> print(a)
+        'I am sakfoo'
+        >>> dryrun(True)
+        >>> b = sakfoo("sport")
+        INFO:drypy.saksag:[DRYRUN] call to 'sakfoo(sport)'
+        >>> print(b)
+        'I am Sakshi'
+
+    """
+    # This is the decorator function, which accepts `return_value`
+    def decorator(func):
+        # This is the actual decorator
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # The wrapper executes based on the `dryrun` condition
+            if dryrun() is False:
+                return func(*args, **kwargs)
+            else:
+                log_call(func, *args, **kwargs)
+                return return_value
+
+        return wrapper
+
+    return decorator  # Return the decorator function

--- a/drypy/tests.py
+++ b/drypy/tests.py
@@ -10,7 +10,7 @@ import unittest
 import logging
 import drypy
 from drypy import dryrun, toggle_dryrun
-from drypy.patterns import sham, sheriff
+from drypy.patterns import sham, sheriff, saksag
 
 
 @sham
@@ -51,6 +51,14 @@ def a_last_func():
     return False
 
 
+@saksag(return_value=789)
+def a_saksag_function():
+    """Just a function decorated by saksag.
+
+    """
+    return 123
+
+
 class AClass:
     """A Class with some methods to be decorated.
 
@@ -80,6 +88,9 @@ class AClass:
     def a_last_method(self):
         return "im the last deputy"
 
+    @saksag(return_value="I am Sakshi. Skipper of the ship.")
+    def a_saksag_method(self):
+        return "I am a saksag method"
 
 class TestModeSwitcher(unittest.TestCase):
     """Test the drypy switcher setting mode on/off
@@ -209,6 +220,31 @@ class TestSheriffDeputyDecorator(unittest.TestCase):
 
         dryrun(True)
         self.assertEqual(instance.a_last_method(), "im the last deputy")
+
+
+class TestSaksagDecorator(unittest.TestCase):
+    """Test the 'saksag' decorator
+
+    """
+    def test_a_saksag_function_dryrun_off(self):
+        dryrun(False)
+        self.assertEqual(a_saksag_function(), 123)
+
+    def test_a_saksag_function_dryrun_on(self):
+        dryrun(True)
+        self.assertEqual(a_saksag_function(), 789)
+
+    def test_a_saksag_method_dryrun_off(self):
+        dryrun(False)
+        an_instance = AClass()
+        self.assertEqual(an_instance.a_saksag_method(), "I am a saksag method")
+
+    def test_a_saksag_method_dryrun_on(self):
+        dryrun(True)
+        an_instance = AClass()
+        self.assertEqual(
+            an_instance.a_saksag_method(), "I am Sakshi. Skipper of the ship."
+        )
 
 
 if __name__ == "__main__":

--- a/drypy/tests.py
+++ b/drypy/tests.py
@@ -10,7 +10,7 @@ import unittest
 import logging
 import drypy
 from drypy import dryrun, toggle_dryrun
-from drypy.patterns import sham, sheriff, saksag
+from drypy.patterns import sham, sheriff, sentinel
 
 
 @sham
@@ -51,9 +51,9 @@ def a_last_func():
     return False
 
 
-@saksag(return_value=789)
-def a_saksag_function():
-    """Just a function decorated by saksag.
+@sentinel(return_value=789)
+def a_sentinel_function():
+    """Just a function decorated by sentinel.
 
     """
     return 123
@@ -88,9 +88,9 @@ class AClass:
     def a_last_method(self):
         return "im the last deputy"
 
-    @saksag(return_value="I am Sakshi. Skipper of the ship.")
-    def a_saksag_method(self):
-        return "I am a saksag method"
+    @sentinel(return_value="I am Sakshi. Skipper of the ship.")
+    def a_sentinel_method(self):
+        return "I am a sentinel method"
 
 class TestModeSwitcher(unittest.TestCase):
     """Test the drypy switcher setting mode on/off
@@ -222,28 +222,32 @@ class TestSheriffDeputyDecorator(unittest.TestCase):
         self.assertEqual(instance.a_last_method(), "im the last deputy")
 
 
-class TestSaksagDecorator(unittest.TestCase):
-    """Test the 'saksag' decorator
+class TestSentinelDecorator(unittest.TestCase):
+    """Test the 'sentinel' decorator
 
     """
-    def test_a_saksag_function_dryrun_off(self):
+    def test_a_sentinel_function_dryrun_off(self):
         dryrun(False)
-        self.assertEqual(a_saksag_function(), 123)
+        self.assertEqual(a_sentinel_function(), 123)
 
-    def test_a_saksag_function_dryrun_on(self):
+    def test_a_sentinel_function_dryrun_on(self):
         dryrun(True)
-        self.assertEqual(a_saksag_function(), 789)
+        self.assertEqual(a_sentinel_function(), 789)
 
-    def test_a_saksag_method_dryrun_off(self):
+    def test_a_sentinel_method_dryrun_off(self):
         dryrun(False)
         an_instance = AClass()
-        self.assertEqual(an_instance.a_saksag_method(), "I am a saksag method")
+        self.assertEqual(
+            an_instance.a_sentinel_method(),
+            "I am a sentinel method"
+        )
 
-    def test_a_saksag_method_dryrun_on(self):
+    def test_a_sentinel_method_dryrun_on(self):
         dryrun(True)
         an_instance = AClass()
         self.assertEqual(
-            an_instance.a_saksag_method(), "I am Sakshi. Skipper of the ship."
+            an_instance.a_sentinel_method(),
+            "I am Sakshi. Skipper of the ship."
         )
 
 


### PR DESCRIPTION
Added a new decorator saksag

- it allows dry run by skipping method execution of the decorated method.
- it will work for all methods with varying parameters list. 
- it will return a user defined value as a response if method execution is skipped to mock the response.
- Corresponding test cases have been added.


Example 1:
        >>> @saksag(return_value=25)
        ... def foo(bar, baz=None):
        ...     return 42
        ...
        >>> a = foo("sport", baz=False)
        >>> print(a)
        42
        >>> dryrun(True)
        >>> b = foo("sport", baz=False)
        INFO:drypy.saksag:[DRYRUN] call to 'foo(sport, baz=False)'
        >>> print(b)
        25

    Example 2:
        >>> @saksag(return_value="I am Sakshi")
        ... def sakfoo(bar):
        ...     return "I am sakfoo"
        ...
        >>> a = sakfoo("sport")
        >>> print(a)
        'I am sakfoo'
        >>> dryrun(True)
        >>> b = sakfoo("sport")
        INFO:drypy.saksag:[DRYRUN] call to 'sakfoo(sport)'
        >>> print(b)
        'I am Sakshi'

